### PR TITLE
Move contributing guidelines to correct path (closes #4)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) of the [Containers Group Project](https://github.com/containers).
+Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/CONTRIBUTING.md) of the [Containers Group Project](https://github.com/containers).


### PR DESCRIPTION
I looked more closely and realized there were two CONTRIBUTING.md files
already in the repo, so this commit moves the detailed one into the
right path.

Closes #4.

Signed-off-by: Justin W. Flory <git@jwf.io>

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
